### PR TITLE
Added global dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1350,12 +1350,6 @@
         }
       }
     },
-    "babylon": {
-      "version": "7.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-      "dev": true
-    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -3745,7 +3739,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3766,12 +3761,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3786,17 +3783,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3913,7 +3913,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3925,6 +3926,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3939,6 +3941,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3946,12 +3949,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3970,6 +3975,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4050,7 +4056,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4062,6 +4069,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4147,7 +4155,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4183,6 +4192,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4202,6 +4212,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4245,12 +4256,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5683,20 +5696,18 @@
       "from": "git+https://github.com/BrandonOCasey/jsdoc.git#feat/plugin-from-cli",
       "dev": true,
       "requires": {
-        "babylon": "7.0.0-beta.19",
         "bluebird": "~3.5.0",
         "catharsis": "~0.8.9",
         "escape-string-regexp": "~1.0.5",
         "js2xmlparser": "~3.0.0",
-        "klaw": "~2.0.0",
-        "markdown-it": "~8.3.1",
-        "markdown-it-named-headers": "~0.0.4",
-        "marked": "~0.3.6",
+        "klaw": "~3.0.0",
+        "markdown-it": "~8.4.2",
+        "marked": "~0.6.0",
         "mkdirp": "~0.5.1",
         "requizzle": "~0.2.1",
         "strip-json-comments": "~2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "~1.8.3"
+        "underscore": "~1.9.1"
       }
     },
     "jsdoctypeparser": {
@@ -6581,15 +6592,6 @@
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.3"
-      }
-    },
-    "markdown-it-named-headers": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz",
-      "integrity": "sha1-gu/CgyQkCmsed7mq5QF3HV81HB8=",
-      "dev": true,
-      "requires": {
-        "string": "^3.0.1"
       }
     },
     "marked": {
@@ -9709,12 +9711,6 @@
           "dev": true
         }
       }
-    },
-    "string": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
-      "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=",
-      "dev": true
     },
     "string-argv": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightcove/react-player-loader",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The official react component for the Brightcove Player",
   "main": "dist/brightcove-react-player-loader.cjs.js",
   "module": "dist/brightcove-react-player-loader.es.js",
@@ -73,6 +73,7 @@
     "conventional-changelog-cli": "^2.0.11",
     "conventional-changelog-videojs": "^3.0.0",
     "doctoc": "^1.4.0",
+    "global": "^4.3.2",
     "husky": "^1.2.0",
     "in-publish": "^2.0.0",
     "jsdoc": "https://github.com/BrandonOCasey/jsdoc#feat/plugin-from-cli",


### PR DESCRIPTION
This package is used in `dist/brightcove-react-player-loader.es.js`. I'm not sure if it needed to be in `dependencies`, but I added it to `devDependencies` like the others