### PR TITLE
feat: Support changes to props

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 A React component to load a Brightcove Player in the browser.
 
 ## Brightcove Player Support
+
 This library has [the same support characteristics as the Brightcove Player Loader](https://github.com/brightcove/player-loader#brightcove-player-support).
 
 ## Table of Contents
@@ -17,48 +18,51 @@ This library has [the same support characteristics as the Brightcove Player Load
 
 
 - [Installation](#installation)
-- [Usage](#usage)
-  - [JSX](#jsx)
-  - [Via `<script>` Tags](#via-script-tags)
-  - [CommonJS](#commonjs)
-  - [ES Module](#es-module)
+- [Standard Usage with JSX](#standard-usage-with-jsx)
 - [Props](#props)
   - [`attrs`](#attrs)
   - [`baseUrl`](#baseurl)
   - [Other Props](#other-props)
+- [Effects of Prop Changes](#effects-of-prop-changes)
 - [View the Demo](#view-the-demo)
+- [Alternate Usage](#alternate-usage)
+  - [ES Module (without JSX)](#es-module-without-jsx)
+  - [CommonJS](#commonjs)
+  - [`<script>` Tag](#script-tag)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Installation
 
+No matter how you use this component, the only place it is available is npm.
+
 ```sh
 npm install --save @brightcove/react-player-loader
 ```
 
-## Usage
+## Standard Usage with JSX
 
-To include `@brightcove/react-player-loader` on your website or web application, use any of the following methods.
+Most React applications are using JSX and the toolchain provided by `create-react-app`.
 
-### JSX
+After installing, `import` the module and use the `ReactPlayerLoader` component like any other component in your React application:
 
-1. Install the module (see [Installation](##Installation))
-2. `import` the module in your javascript. IE `import ReactPlayerLoader from '@brightcove/react-player-loader'`
-3. Now you can use it however you like, with the `ReactPlayerLoader` variable.
-4. See the example below for full usage.
-
-> NOTE: React/ReactDOM/global are **NOT** required, they are only used to show a working example.
+> **NOTE:** `React`/`ReactDOM` are **NOT** required, they are only used here to show a complete working example!
 
 ```js
-import document from 'global/document';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactPlayerLoader from '@brightcove/react-player-loader';
 
 let reactPlayerLoader;
 const onSuccess = function(success) {
-  // two ways to get the underlying player/iframe at this point.
-  console.log(success.ref)
+
+  // The player object or iframe element (depending on embed type) can be
+  // accessed in two ways.
+  // 
+  // From the success object passed to the `onSuccess` callback:
+  console.log(success.ref);
+
+  // As a property of the component instance:
   console.log(reactPlayerLoader.player);
 };
 
@@ -66,84 +70,76 @@ reactPlayerLoader = ReactDOM.render(
   <ReactPlayerLoader accountId='1234678' onSuccess={onSuccess}/>,
   document.getElementById('fixture')
 );
-
 ```
 
-### Via `<script>` Tags
+See [Alternate Usage](#alternate-usage) below for less common ways to use this component.
 
-1. Get the script however you prefer
-2. Include the script in your html
-3. Use the `BrightcoveReactPlayerLoader` object that this module exports on the `window` object.
-4. See the example below for full usage.
+## Props
 
-> NOTE: React/ReactDOM are **NOT** required, they are only used to show a working example.
+### `attrs`
 
-```html
-<div id="fixture"></div>
-<script src="//path/to/react.min.js"></script>
-<script src="//path/to/react-dom.min.js"></script>
-<script src="//path/to/brightcove-react-player-loader.min.js"></script>
-<script>
+Type: `Object`
 
-  var React = window.React;
-  var ReactDOM = window.ReactDOM;
-  var ReactPlayerLoader = window.BrightcoveReactPlayerLoader;
+Provides attributes (props) to the component element.
 
-  var reactPlayerLoader = window.reactPlayerLoader = ReactDOM.render(
-    React.createElement(ReactPlayerLoader, {
-      accountId: '1234678',
-      onSuccess: function(success) {
-        // two ways to get the underlying player/iframe at this point.
-        console.log(success.ref)
-        console.log(reactPlayerLoader.player);
-      }
-    }),
-    document.getElementById('fixture')
-  );
+For example, you may want to customize the `className` of the component (by default, `"brightcove-react-player-loader"`) by setting props on the component like so:
 
-</script>
+```jsx
+<ReactPlayerLoader attrs={{className: 'my-custom-class'}} />
 ```
 
-### CommonJS
+### `baseUrl`
 
-1. Install the module (see [Installation](##Installation))
-2. `require` the module in your javascript. IE `var ReactPlayerLoader = require('@brightcove/react-player-loader')`
-3. Now you can use it however you like, with the `ReactPlayerLoader` variable.
-4. See the example below for full usage.
+Type: `string`
 
-> NOTE: React/ReactDOM/global are **NOT** required, they are only used to show a working example.
+Used to override the base URL for the Brightcove Player being embedded.
+
+Most users will never need this prop. By default, players are loaded from Brightcove's player CDN (`players.brightcove.net`).
+
+### Other Props
+
+All props not specified above are passed to the [Brightcove Player Loader](https://github.com/brightcove/player-loader#parameters) with a few differences:
+
+1. We cannot expose the Player Loader promise easily, so you must use the `onSuccess` and `onFailure` callbacks.
+2. If you don't provide an `onFailure` callback, the failure will be handled by throwing an error.
+3. We need to use `refNode` and `refNodeInsert` internally, so those props will be ignored.
+
+## Effects of Prop Changes
+
+When a prop passed to this component changes, it will have one of two effects:
+
+1. Dispose/reload the player. This is the most common case.
+1. Update the player's state (e.g. fetch a new video).
+
+The following props will update the player's state _without_ a reload:
+
+- `catalogSearch`
+- `catalogSequence`
+- `playlistId`
+- `playlistVideoId`
+- `videoId`
+
+All other prop changes will cause a complete dispose/reload.
+
+## View the Demo
+
+This repository includes a barebones demo/example page.
+
+1. Clone the repository
+2. Move into the repository
+3. Run `npm install`
+4. Run `npm start`
+5. Navigate to `http://localhost:9999` in a browser
+
+## Alternate Usage
+
+### ES Module (without JSX)
+
+After installation, `import` the module in your JavaScript and use the `ReactPlayerLoader` component like any other component in your React application:
+
+> **NOTE:** `React`/`ReactDOM` are **NOT** required, they are only used here to show a complete working example!
 
 ```js
-var React = require('react');
-var ReactDOM = require('react-dom');
-var document = require('global/document');
-var ReactPlayerLoader = require('@brightcove/react-player-loader');
-
-var reactPlayerLoader = ReactDOM.render(
-  React.createElement(ReactPlayerLoader, {
-    accountId: '1234678',
-    onSuccess: function(success) {
-      // two ways to get the underlying player/iframe at this point.
-      console.log(success.ref)
-      console.log(reactPlayerLoader.player);
-    }
-  }),
-  document.getElementById('fixture')
-);
-
-```
-
-### ES Module
-
-1. Install the module (see [Installation](##Installation))
-2. `import` the module in your javascript. IE `import ReactPlayerLoader from '@brightcove/react-player-loader'`
-3. Now you can use it however you like, with the `ReactPlayerLoader` variable.
-4. See the example below for full usage.
-
-> NOTE: React/ReactDOM/global are **NOT** required, they are only used to show a working example.
-
-```js
-import document from 'global/document';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactPlayerLoader  from '@brightcove/react-player-loader';
@@ -162,42 +158,59 @@ const reactPlayerLoader = ReactDOM.render(
 
 ```
 
-## Props
+### CommonJS
 
-### `attrs`
-Type: `Object`
+After installation, `require` the module in your JavaScript and use the `ReactPlayerLoader` component like any other component in your React application:
 
-Provides attributes (props) to the component element.
+> **NOTE:** `React`/`ReactDOM` are **NOT** required, they are only used here to show a complete working example!
 
-For example, you may want to customize the `className` of the component (by default, `"brightcove-react-player-loader"`) by setting props on the component like so:
+```js
+var React = require('react');
+var ReactDOM = require('react-dom');
+var ReactPlayerLoader = require('@brightcove/react-player-loader');
 
-```jsx
-<ReactPlayerLoader attrs={{className: 'my-custom-class'}} />
+var reactPlayerLoader = ReactDOM.render(
+  React.createElement(ReactPlayerLoader, {
+    accountId: '1234678',
+    onSuccess: function(success) {
+      // two ways to get the underlying player/iframe at this point.
+      console.log(success.ref)
+      console.log(reactPlayerLoader.player);
+    }
+  }),
+  document.getElementById('fixture')
+);
+
 ```
 
-### `baseUrl`
-Type: `string`
+### `<script>` Tag
 
-Used to override the base URL for the Brightcove Player being embedded.
+_This case is extremely unlikely to be used._
 
-Most users will never need this prop. By default, players are loaded from Brightcove's player CDN (`players.brightcove.net`).
+After installation or loading from a CDN, use a `script` tag to include the module in your HTML and use the global `window.BrightcoveReactPlayerLoader` to construct the component.
 
-### Other Props
-All props not specified above are passed to the [Brightcove Player Loader](https://github.com/brightcove/player-loader#parameters) with a few differences:
+```html
+<div id="fixture"></div>
+<script src="//path/to/react.min.js"></script>
+<script src="//path/to/react-dom.min.js"></script>
+<script src="//path/to/brightcove-react-player-loader.min.js"></script>
+<script>
+  var React = window.React;
+  var ReactDOM = window.ReactDOM;
 
-1. We cannot expose the promise easily, so you will have to use the `onSuccess` and `onFailure` callbacks.
-2. If you don't provide an `onFailure` callback, the failure will be handled by throwing an error.
-3. We need to use `refNode` and `refNodeInsert` internally, so those options will not be used if passed in.
-
-## View the Demo
-This repository includes a barebones demo/example page.
-
-1. Clone the repository
-2. Move into the repository
-3. Run `npm install`
-4. Run `npm start`
-5. Navigate to `http://localhost:9999` in a browser
-
+  var reactPlayerLoader = ReactDOM.render(
+    React.createElement(window.BrightcoveReactPlayerLoader, {
+      accountId: '1234678',
+      onSuccess: function(success) {
+        // two ways to get the underlying player/iframe at this point.
+        console.log(success.ref)
+        console.log(reactPlayerLoader.player);
+      }
+    }),
+    document.getElementById('fixture')
+  );
+</script>
+```
 
 [react]: https://www.npmjs.com/package/react
 [react-dom]: https://www.npmjs.com/package/react-dom

--- a/index.html
+++ b/index.html
@@ -12,20 +12,19 @@
     (function() {
       var React = window.React;
       var ReactDOM = window.ReactDOM;
-      var ReactPlayerLoader = window.BrightcoveReactPlayerLoader;
 
-      var reactPlayerLoader = window.reactPlayerLoader = ReactDOM.render(
-        React.createElement(ReactPlayerLoader, {
+      window.reactPlayerLoader = ReactDOM.render(
+        React.createElement(window.BrightcoveReactPlayerLoader, {
           accountId: '1',
-          baseUrl: window.location.origin + '/vendor/',
-          onSuccess: function(success) {
-            // two ways to get the underlying player/iframe at this point.
-            console.log(success.ref)
-            console.log(reactPlayerLoader.player);
-          }
+          videoId: '2',
+          baseUrl: window.location.origin + '/vendor/'
         }),
         document.getElementById('fixture')
       );
+
+      if (console) {
+        console.log('the component instance is available as window.reactPlayerLoader');
+      }
     })();
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -4,28 +4,49 @@
   <meta charset="utf-8">
 </head>
 <body>
+  <p>Nothing will appear below because this page uses an invalid account ID by default.</p>
+  <p>Open the console and use <code>window.customApp.setState({})</code> to try changing props.</p>
   <div id="fixture"></div>
   <script src="node_modules/react/umd/react.development.js"></script>
   <script src="node_modules/react-dom/umd/react-dom.development.js"></script>
+  <script src="node_modules/create-react-class/create-react-class.js"></script>
   <script src="dist/brightcove-react-player-loader.js"></script>
   <script>
     (function() {
+      var fixture = document.getElementById('fixture');
       var React = window.React;
       var ReactDOM = window.ReactDOM;
+      var MyCustomApp = window.createReactClass({
+        getInitialState: function() {
+          return {
 
-      window.reactPlayerLoader = ReactDOM.render(
-        React.createElement(window.BrightcoveReactPlayerLoader, {
-          accountId: '1',
-          videoId: '2',
-          baseUrl: window.location.origin + '/vendor/'
-        }),
-        document.getElementById('fixture')
-      );
+            // Put your account ID, player ID, or other settings here...
+            accountId: 1,
+            videoId: 2
+          };
+        },
+        render: function() {
+          return React.createElement(window.BrightcoveReactPlayerLoader, {
+            accountId: this.state.accountId,
+            videoId: this.state.videoId,
+            onSuccess: function(player) {
+              if (console) {
+                console.log('successfully created player', player);
+              }
+            },
+            onFailure: function(err) {
+              if (console) {
+                console.log('failed to create player', err);
+              }
+            },
+            key: this.state
+          });
+        }
+      });
 
-      if (console) {
-        console.log('the component instance is available as window.reactPlayerLoader');
-      }
+      window.customApp = ReactDOM.render(React.createElement(MyCustomApp), fixture);
     })();
+
   </script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,6 +1254,12 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -2411,6 +2417,17 @@
         "parse-json": "^4.0.0"
       }
     },
+    "create-react-class": {
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2761,6 +2778,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -3420,6 +3446,29 @@
       "dev": true,
       "requires": {
         "format": "^0.2.2"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
       }
     },
     "figures": {
@@ -5390,6 +5439,16 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -6133,9 +6192,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -6169,9 +6228,9 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.pad": {
@@ -6592,9 +6651,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -6708,6 +6767,16 @@
         "just-extend": "^4.0.2",
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-releases": {
@@ -7852,6 +7921,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -8699,9 +8777,9 @@
       }
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -8720,6 +8798,12 @@
           }
         }
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -9782,6 +9866,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+      "dev": true
+    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -9873,38 +9963,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unist-util-is": {
@@ -10185,6 +10252,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.2.0.tgz",
       "integrity": "sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
       "dev": true
     },
     "which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -831,9 +831,9 @@
       }
     },
     "@brightcove/player-loader": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@brightcove/player-loader/-/player-loader-1.7.0.tgz",
-      "integrity": "sha512-jSLxEHkBoHgFnNqymHUO+COmdMG3BLlbOk1Ey0Jz2DdQP4mXkTJSvgqVmcLHBQBvAVxIjG4Ojix0dk2pxka9fg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@brightcove/player-loader/-/player-loader-1.7.1.tgz",
+      "integrity": "sha512-shmLow7y8ECiqKBYlawnhnMuniBHjPJK5evrH5dFciji/WWwB0IwHLKdbxN8u59I1dIum4prPNxjUOt07a7CXA==",
       "requires": {
         "@brightcove/player-url": "^1.2.0",
         "global": "^4.3.2"
@@ -844,6 +844,17 @@
       "resolved": "https://registry.npmjs.org/@brightcove/player-url/-/player-url-1.2.0.tgz",
       "integrity": "sha512-MhmB5JZAAPG3l3FbLiDrkNo5TKQI4Mp1xZmKk1y0DrIibh1loE14raabI30X3rizKT5ThTdvRmLlVMENUn7Gvw=="
     },
+    "@jest/types": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+      "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^12.0.9"
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -851,6 +862,71 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
+      }
+    },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "@testing-library/dom": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.4.0.tgz",
+      "integrity": "sha512-0OQsquNYfbxgqqoGf9RZ9lglXEYgKlhSe+W9UFQGDAvT554Y9PG6hGe0RHYggAXe/GoNPccSsl65nn+qq0cFKw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.8.0",
+        "wait-for-expect": "^1.2.0"
+      }
+    },
+    "@testing-library/react": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.1.tgz",
+      "integrity": "sha512-N/1pJfhEnNYkGyxuw4xbp03evaS0z/CT8o0QgTfJqGlukAcU15xf9uU1w03NHKZJcU69nOCBAoAkXHtHzYwMbg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "@testing-library/dom": "^5.0.0"
       }
     },
     "@textlint/ast-node-types": {
@@ -880,10 +956,35 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/node": {
-      "version": "10.12.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.14.tgz",
-      "integrity": "sha512-0rVcFRhM93kRGAU88ASCjX9Y3FWDCh+33G5Z5evpKOea4xcpLqDGwmo64+DjgaSezTN5j9KdnUzvxhOw7fNciQ==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
+      "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
       "dev": true
     },
     "@types/resolve": {
@@ -894,6 +995,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/yargs": {
+      "version": "12.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+      "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+      "dev": true
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -1050,6 +1157,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -1078,6 +1195,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-ify": {
@@ -1135,6 +1258,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
     "astral-regex": {
@@ -1536,6 +1665,26 @@
         "ps-tree": "=1.1.1",
         "sinon": "^1.17.6",
         "temp-fs": "^0.9.9"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+          "dev": true
+        },
+        "sinon": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+          "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+          "dev": true,
+          "requires": {
+            "formatio": "1.1.1",
+            "lolex": "1.3.2",
+            "samsam": "1.1.2",
+            "util": ">=0.10.3 <1"
+          }
+        }
       }
     },
     "buffer-alloc": {
@@ -2231,9 +2380,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz",
+          "integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ==",
           "dev": true
         }
       }
@@ -2471,6 +2620,12 @@
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "doctoc": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/doctoc/-/doctoc-1.4.0.tgz",
@@ -2584,9 +2739,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.167",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.167.tgz",
-      "integrity": "sha512-84IjpeRudjP43Q0+K7tlS7ESoHOl0W6CIdzs5reS9p+sAjCQEDiaAyiXN2v1qLUdL+Of6ZSaH4Cq6bl+sfzy8A==",
+      "version": "1.3.172",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.172.tgz",
+      "integrity": "sha512-bHgFvYeHBiQNNuY/WvoX37zLosPgMbR8nKU1r4mylHptLvuMMny/KG/L28DTIlcoOCJjMAhEimy3DHDgDayPbg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -5511,6 +5666,12 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "karma": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-4.1.0.tgz",
@@ -6143,9 +6304,9 @@
       }
     },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
       "dev": true
     },
     "loose-envify": {
@@ -6535,6 +6696,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-releases": {
       "version": "1.1.23",
@@ -7420,6 +7594,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -7599,6 +7790,26 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+      "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
+      }
     },
     "prettyjson": {
       "version": "1.2.1",
@@ -8161,23 +8372,32 @@
       }
     },
     "rollup": {
-      "version": "0.67.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.67.4.tgz",
-      "integrity": "sha512-AVuP73mkb4BBMUmksQ3Jw0jTrBTU1i7rLiUYjFxLZGb3xiFmtVEg40oByphkZAsiL0bJC3hRAJUQos/e5EBd+w==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.16.2.tgz",
+      "integrity": "sha512-UAZxaQvH0klYZdF+90xv9nGb+m4p8jdoaow1VL5/RzDK/gN/4CjvaMmJNcOIv1/+gtzswKhAg/467mzF0sLpAg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*"
+        "@types/node": "^12.0.8",
+        "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.0.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
+          "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-babel": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz",
-      "integrity": "sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz",
+      "integrity": "sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
-        "rollup-pluginutils": "^2.3.0"
+        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-plugin-commonjs": {
@@ -8193,9 +8413,9 @@
       },
       "dependencies": {
         "resolve": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-          "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -8250,9 +8470,9 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-          "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -8597,15 +8817,18 @@
       }
     },
     "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
       }
     },
     "slash": {
@@ -9370,14 +9593,6 @@
         "commander": "^2.19.0",
         "source-map": "~0.6.1",
         "source-map-support": "~0.5.10"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-          "dev": true
-        }
       }
     },
     "text-extensions": {
@@ -9544,6 +9759,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -9958,6 +10179,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
+    },
+    "wait-for-expect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.2.0.tgz",
+      "integrity": "sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -68,9 +68,10 @@
     "test/"
   ],
   "dependencies": {
-    "@brightcove/player-loader": "^1.7.0"
+    "@brightcove/player-loader": "^1.7.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^8.0.1",
     "conventional-changelog-cli": "^2.0.21",
     "conventional-changelog-videojs": "^3.0.0",
     "doctoc": "^1.4.0",
@@ -85,8 +86,9 @@
     "pkg-ok": "^2.3.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "rollup": "^0.67.4",
+    "rollup": "^1.16.2",
     "shx": "^0.3.2",
+    "sinon": "^7.3.2",
     "videojs-generate-karma-config": "^5.3.0",
     "videojs-generate-rollup-config": "^3.2.0",
     "videojs-generator-verify": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@testing-library/react": "^8.0.1",
     "conventional-changelog-cli": "^2.0.21",
     "conventional-changelog-videojs": "^3.0.0",
+    "create-react-class": "^15.6.3",
     "doctoc": "^1.4.0",
     "husky": "^1.3.1",
     "in-publish": "^2.0.0",

--- a/scripts/karma.conf.js
+++ b/scripts/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function(config) {
     files(defaults) {
       // defaults don't work for this project
       return [
+        'node_modules/sinon/pkg/sinon.js',
         'node_modules/react/umd/react.development.js',
         'node_modules/react-dom/umd/react-dom.development.js',
         'test/dist/bundle.js'

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -27,6 +27,9 @@ const options = {
       }),
       module: defaults.module,
       test: Object.assign(defaults.test, {
+
+        // This is a deep dependency of @testing-library/react that doesn't
+        // play nice with Rollup...
         '@sheerun/mutationobserver-shim': 'MutationObserver',
         'react': 'React',
         'react-dom': 'ReactDOM'

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -27,6 +27,7 @@ const options = {
       }),
       module: defaults.module,
       test: Object.assign(defaults.test, {
+        '@sheerun/mutationobserver-shim': 'MutationObserver',
         'react': 'React',
         'react-dom': 'ReactDOM'
       })

--- a/src/index.js
+++ b/src/index.js
@@ -85,9 +85,11 @@ class ReactPlayerLoader extends React.Component {
 
         // Null out the player reference when the player is disposed from
         // outside the component.
-        ref.on('dispose', () => {
-          this.player = null;
-        });
+        if (type === 'in-page') {
+          ref.on('dispose', () => {
+            this.player = null;
+          });
+        }
 
         // Add a REACT_PLAYER_LOADER property to bcinfo to indicate this player
         // was loaded via that mechanism.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,10 @@
 import document from 'global/document';
 import window from 'global/window';
 import QUnit from 'qunit';
+import sinon from 'sinon';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {render, cleanup} from '@testing-library/react';
 import ReactPlayerLoader from '../src/index.js';
 import BrightcovePlayerLoader from '@brightcove/player-loader';
 
@@ -13,93 +15,612 @@ QUnit.module('ReactPlayerLoader', {
     BrightcovePlayerLoader.setBaseUrl(`${window.location.origin}/vendor/`);
   },
   afterEach() {
-    // reset the base url
+    cleanup();
+
+    // reset the base url and global state
     BrightcovePlayerLoader.setBaseUrl(this.originalBaseUrl);
+    BrightcovePlayerLoader.reset();
 
     // unmount all components on the fixture
     ReactDOM.unmountComponentAtNode(this.fixture);
   }
-});
+}, function() {
 
-QUnit.test('failure', function(assert) {
-  const done = assert.async();
+  QUnit.module('baseline usage');
 
-  assert.expect(2);
+  QUnit.test('failure', function(assert) {
+    const done = assert.async();
 
-  const reactPlayerLoader = ReactDOM.render(
-    React.createElement(ReactPlayerLoader, {
-      accountId: '2',
-      onFailure: (failure) => {
-        assert.ok(failure, 'failed to download non-existent player');
+    assert.expect(2);
+
+    const reactPlayerLoader = ReactDOM.render(
+      React.createElement(ReactPlayerLoader, {
+        accountId: '2',
+        onFailure: (failure) => {
+          assert.ok(failure, 'failed to download non-existent player');
+          done();
+        }
+      }),
+      this.fixture
+    );
+
+    assert.ok(reactPlayerLoader, 'player loader react component created');
+  });
+
+  QUnit.test('success', function(assert) {
+    const done = assert.async();
+
+    assert.expect(2);
+
+    const reactPlayerLoader = ReactDOM.render(
+      React.createElement(ReactPlayerLoader, {
+        accountId: '1',
+        onSuccess: ({ref, type}) => {
+          assert.ok(ref, 'downloaded and created a player');
+          done();
+        }
+      }),
+      this.fixture
+    );
+
+    assert.ok(reactPlayerLoader, 'player loader react component created');
+  });
+
+  QUnit.test('unmount after success', function(assert) {
+    const done = assert.async();
+
+    assert.expect(2);
+
+    const reactPlayerLoader = ReactDOM.render(
+      React.createElement(ReactPlayerLoader, {
+        accountId: '1',
+        onSuccess: ({ref, type}) => {
+          assert.ok(ref, 'downloaded and created a player');
+          window.setTimeout(() => {
+            ReactDOM.unmountComponentAtNode(this.fixture);
+            done();
+          }, 1);
+        }
+      }),
+      this.fixture
+    );
+
+    assert.ok(reactPlayerLoader, 'player loader react component created');
+  });
+
+  QUnit.module('attrs');
+
+  QUnit.test('can set attributes on the component element', function(assert) {
+    const done = assert.async();
+
+    assert.expect(1);
+
+    ReactDOM.render(
+      React.createElement(ReactPlayerLoader, {
+        accountId: '1',
+        attrs: {foo: 'bar'},
+        onSuccess: ({ref, type}) => {
+          window.setTimeout(done, 1);
+        }
+      }),
+      this.fixture
+    );
+
+    assert.ok(this.fixture.querySelector('div[foo="bar"]'), 'foo="bar" div exists');
+  });
+
+  QUnit.test('className defaults to "brightcove-react-player-loader"', function(assert) {
+    const done = assert.async();
+
+    assert.expect(1);
+
+    ReactDOM.render(
+      React.createElement(ReactPlayerLoader, {
+        accountId: '1',
+        attrs: {id: 'test'},
+        onSuccess: ({ref, type}) => {
+          window.setTimeout(done, 1);
+        }
+      }),
+      this.fixture
+    );
+
+    const el = this.fixture.querySelector('#test');
+
+    assert.strictEqual(el.className, 'brightcove-react-player-loader', 'component element has correct className');
+  });
+
+  QUnit.test('className can be set to override default', function(assert) {
+    const done = assert.async();
+
+    assert.expect(1);
+
+    ReactDOM.render(
+      React.createElement(ReactPlayerLoader, {
+        accountId: '1',
+        attrs: {
+          className: 'foo bar',
+          id: 'test'
+        },
+        onSuccess: ({ref, type}) => {
+          window.setTimeout(done, 1);
+        }
+      }),
+      this.fixture
+    );
+
+    const el = this.fixture.querySelector('#test');
+
+    assert.strictEqual(el.className, 'foo bar', 'component element has correct className');
+  });
+
+  QUnit.module('props', {
+    beforeEach() {
+
+      // This mock catalog plugin takes custom options for testing purposes.
+      // The ReactPlayerLoader expects that the player will have initialized
+      // the Video Cloud Catalog plugin itself.
+      //
+      // The custom options for the mock plugin instruct it whether or not to
+      // produce "error" cases.
+      this.mockCatalogPlugin = function(options = {}) {
+        const err = new Error('mock catalog request failure');
+
+        this.catalog = {
+          getLazySequence(seq, cb, adConfigId) {
+            if (options.error) {
+              cb(err, null);
+            } else {
+              cb(null, options.data || [{foo: 1}]);
+            }
+          },
+          get(params, cb) {
+            let result = {foo: 1};
+
+            if (params.type === 'playlist' || params.type === 'search') {
+              result = [result, {foo: 2}];
+            }
+
+            if (options.error) {
+              cb(err, null);
+            } else {
+              cb(null, options.data || result);
+            }
+          },
+          load(data) {
+            return data;
+          }
+        };
+
+        Object.keys(this.catalog).forEach(key => sinon.spy(this.catalog, key));
+      };
+
+      this.mockPlaylistPlugin = function(list = [], currentItem = 0) {
+        this.playlist = (l, i) => {
+          if (l !== undefined) {
+            list = l;
+            if (i > -1) {
+              currentItem = i;
+            }
+          }
+          return list;
+        };
+
+        this.playlist.currentItem = (i) => {
+          if (i !== undefined) {
+            currentItem = i;
+          }
+          return currentItem;
+        };
+
+        sinon.spy(this.playlist, 'currentItem');
+      };
+    },
+    afterEach() {
+      this.mockCatalogPlugin = null;
+      this.mockPlaylistPlugin = null;
+    }
+  });
+
+  QUnit.test('change catalogSearch, success response', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      adConfigId: 'abc-123',
+      deliveryConfigId: 'def-456',
+      catalogSearch: '2',
+      onSuccess: ({ref, type}) => {
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog();
+
+        props.catalogSearch = '3';
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.calledOnce, 'player.catalog.get was called');
+        assert.ok(ref.catalog.load.calledOnce, 'player.catalog.load was called');
+
+        const params = ref.catalog.get.getCall(0).args[0];
+
+        assert.deepEqual(params, {
+          adConfigId: 'abc-123',
+          deliveryConfigId: 'def-456',
+          q: '3',
+          type: 'search'
+        }, 'catalog params were correct');
+
         done();
       }
-    }),
-    this.fixture
-  );
+    };
 
-  assert.ok(reactPlayerLoader, 'player loader react component created');
-});
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
 
-QUnit.test('success', function(assert) {
-  const done = assert.async();
+  QUnit.test('change catalogSearch, failure response', function(assert) {
+    const done = assert.async();
 
-  assert.expect(2);
+    let rerender;
 
-  const reactPlayerLoader = ReactDOM.render(
-    React.createElement(ReactPlayerLoader, {
+    const props = {
       accountId: '1',
+      catalogSearch: '2',
       onSuccess: ({ref, type}) => {
-        assert.ok(ref, 'downloaded and created a player');
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog({error: true});
+
+        props.catalogSearch = '3';
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.calledOnce, 'player.catalog.get was called');
+        assert.ok(ref.catalog.load.notCalled, 'player.catalog.load was not called');
+
         done();
       }
-    }),
-    this.fixture
-  );
+    };
 
-  assert.ok(reactPlayerLoader, 'player loader react component created');
-});
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
 
-QUnit.test('unmount after success', function(assert) {
-  const done = assert.async();
+  QUnit.test('change catalogSequence, success response', function(assert) {
+    const done = assert.async();
 
-  assert.expect(2);
+    let rerender;
 
-  const reactPlayerLoader = ReactDOM.render(
-    React.createElement(ReactPlayerLoader, {
+    const props = {
       accountId: '1',
+      adConfigId: 'abc-123',
+      deliveryConfigId: 'def-456',
+      catalogSequence: [{}],
       onSuccess: ({ref, type}) => {
-        assert.ok(ref, 'downloaded and created a player');
-        window.setTimeout(() => {
-          ReactDOM.unmountComponentAtNode(this.fixture);
-          done();
-        }, 1);
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog();
+
+        props.catalogSequence = [{}, {}];
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.notCalled, 'player.catalog.get was not called');
+        assert.ok(ref.catalog.getLazySequence.calledOnce, 'player.catalog.getLazySequence was called');
+        assert.ok(ref.catalog.load.calledOnce, 'player.catalog.load was called');
+
+        const seq = ref.catalog.getLazySequence.getCall(0).args[0];
+
+        assert.deepEqual(seq, props.catalogSequence, 'catalog sequence was correct');
+
+        done();
       }
-    }),
-    this.fixture
-  );
+    };
 
-  assert.ok(reactPlayerLoader, 'player loader react component created');
-});
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
 
-QUnit.test('attrs', function(assert) {
-  const done = assert.async();
+  QUnit.test('change catalogSequence, failure response', function(assert) {
+    const done = assert.async();
 
-  assert.expect(1);
+    let rerender;
 
-  ReactDOM.render(
-    React.createElement(ReactPlayerLoader, {
+    const props = {
       accountId: '1',
-      attrs: {foo: 'bar'},
+      catalogSequence: [{}],
       onSuccess: ({ref, type}) => {
-        window.setTimeout(() => {
-          ReactDOM.unmountComponentAtNode(this.fixture);
-          done();
-        }, 1);
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog({error: true});
+
+        props.catalogSequence = [{}, {}];
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.notCalled, 'player.catalog.get was not called');
+        assert.ok(ref.catalog.getLazySequence.calledOnce, 'player.catalog.getLazySequence was called');
+        assert.ok(ref.catalog.load.notCalled, 'player.catalog.load was not called');
+
+        done();
       }
-    }),
-    this.fixture
-  );
+    };
 
-  assert.ok(this.fixture.querySelector('div[foo="bar"]'), 'foo="bar" div exists');
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
+
+  QUnit.test('change playlistId, success response', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      adConfigId: 'abc-123',
+      deliveryConfigId: 'def-456',
+      playlistId: '2',
+      onSuccess: ({ref, type}) => {
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog();
+
+        props.playlistId = '3';
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.calledOnce, 'player.catalog.get was called');
+        assert.ok(ref.catalog.load.calledOnce, 'player.catalog.load was called');
+
+        const params = ref.catalog.get.getCall(0).args[0];
+
+        assert.deepEqual(params, {
+          adConfigId: 'abc-123',
+          deliveryConfigId: 'def-456',
+          id: '3',
+          type: 'playlist'
+        }, 'catalog params were correct');
+
+        done();
+      }
+    };
+
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
+
+  QUnit.test('change playlistId, failure response', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      playlistId: '2',
+      onSuccess: ({ref, type}) => {
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog({error: true});
+
+        props.playlistId = '3';
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.calledOnce, 'player.catalog.get was called');
+        assert.ok(ref.catalog.load.notCalled, 'player.catalog.load was not called');
+
+        done();
+      }
+    };
+
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
+
+  QUnit.test('change videoId, success response', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      adConfigId: 'abc-123',
+      deliveryConfigId: 'def-456',
+      videoId: '2',
+      onSuccess: ({ref, type}) => {
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog();
+
+        props.videoId = '3';
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.calledOnce, 'player.catalog.get was called');
+        assert.ok(ref.catalog.load.calledOnce, 'player.catalog.load was called');
+
+        const params = ref.catalog.get.getCall(0).args[0];
+
+        assert.deepEqual(params, {
+          adConfigId: 'abc-123',
+          deliveryConfigId: 'def-456',
+          id: '3',
+          type: 'video'
+        }, 'catalog params were correct');
+
+        done();
+      }
+    };
+
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
+
+  QUnit.test('change videoId, failure response', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      videoId: '2',
+      onSuccess: ({ref, type}) => {
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog({error: true});
+
+        props.videoId = '3';
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.calledOnce, 'player.catalog.get was called');
+        assert.ok(ref.catalog.load.notCalled, 'player.catalog.load was not called');
+
+        done();
+      }
+    };
+
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
+
+  QUnit.test('change from one catalog request type to another ignores previous props', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      adConfigId: 'abc-123',
+      deliveryConfigId: 'def-456',
+      catalogSearch: '0',
+      catalogSequence: '1',
+      playlistId: '2',
+      videoId: '3',
+      onSuccess: ({ref, type}) => {
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog();
+
+        props.playlistId = '4';
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.calledOnce, 'player.catalog.get was called');
+        assert.ok(ref.catalog.load.calledOnce, 'player.catalog.load was called');
+
+        const params = ref.catalog.get.getCall(0).args[0];
+
+        assert.deepEqual(params, {
+          adConfigId: 'abc-123',
+          deliveryConfigId: 'def-456',
+          id: '4',
+          type: 'playlist'
+        }, 'props that trigger a type of catalog request and were not changed were not included');
+
+        done();
+      }
+    };
+
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
+
+  QUnit.test('changing playlistId + playlistVideoId, success response', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      embedOptions: {unminified: true},
+      playlistId: '0',
+      playlistVideoId: '0',
+      onSuccess: ({ref, type}) => {
+        const playlist = [{
+          id: 1
+        }, {
+          id: 2
+        }];
+
+        window.videojs.registerPlugin('catalog', this.mockCatalogPlugin);
+        ref.catalog({data: playlist});
+
+        props.playlistId = '1';
+        props.playlistVideoId = 2;
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.ok(ref.catalog.get.calledOnce, 'player.catalog.get was called');
+        assert.ok(ref.catalog.load.calledOnce, 'player.catalog.load was called');
+
+        const params = ref.catalog.get.getCall(0).args[0];
+
+        assert.deepEqual(params, {
+          id: '1',
+          type: 'playlist'
+        }, 'catalog params were correct');
+
+        // The test players have the playlist plugin, but we want a minimal
+        // test case for playlists; so, we remove it and mock a new plugin.
+        window.videojs.getPlugin('plugin').deregisterPlugin('playlist');
+        delete ref.playlist;
+
+        window.videojs.registerPlugin('playlist', this.mockPlaylistPlugin);
+        ref.playlist(playlist, playlist.startingIndex);
+
+        assert.strictEqual(ref.playlist.currentItem(), 1, 'the second playlist item is selected');
+
+        done();
+      }
+    };
+
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
+
+  QUnit.test('changing playlistVideoId on an already loaded playlist, using referenceId instead of id', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      playlistId: '0',
+      playlistVideoId: '0',
+      onSuccess: ({ref, type}) => {
+
+        // The test players have the playlist plugin, but we want a minimal
+        // test case for playlists; so, we remove it and mock a new plugin.
+        window.videojs.getPlugin('plugin').deregisterPlugin('playlist');
+        delete ref.playlist;
+
+        window.videojs.registerPlugin('playlist', this.mockPlaylistPlugin);
+        ref.playlist([{
+          id: 1
+        }, {
+          id: 2
+        }, {
+          id: 3,
+          referenceId: 'foo'
+        }]);
+
+        props.playlistVideoId = 'ref:foo';
+
+        rerender(React.createElement(ReactPlayerLoader, props));
+
+        assert.strictEqual(ref.playlist.currentItem(), 2, 'the third playlist item is selected');
+
+        done();
+      }
+    };
+
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
+
+  QUnit.test('other prop changes reload the player', function(assert) {
+    const done = assert.async();
+
+    let rerender;
+
+    const props = {
+      accountId: '1',
+      applicationId: 'foo',
+      onSuccess: ({ref, type}) => {
+        if (props.applicationId === 'bar') {
+          assert.ok(true, 'the success callback was called a second time because the player was re-loaded');
+          done();
+        }
+
+        props.applicationId = 'bar';
+        rerender(React.createElement(ReactPlayerLoader, props));
+      }
+    };
+
+    rerender = render(React.createElement(ReactPlayerLoader, props)).rerender;
+  });
 });
-


### PR DESCRIPTION
Fixes #38 

This will implement support for changes to props and does some general code cleanup.

The main change is that there is now a list of `UPDATEABLE_PROPS`. When any prop changes occur, we look through this list and compare it to the list of props that changed. If any props change that _are not_ in this list, the player cannot be updated in place and will be re-created.