### PR TITLE
Add onEmbedCreated passthrough.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ class ReactPlayerLoader extends React.Component {
     // user-provided callbacks for use later.
     const userSuccess = this.props.onSuccess;
     const userFailure = this.props.onFailure;
+    const userOnEmbedCreated = this.props.onEmbedCreated;
 
     const options = Object.assign({}, this.props, {
       refNode: this.refNode,
@@ -122,6 +123,12 @@ class ReactPlayerLoader extends React.Component {
 
         // Fall back to throwing an error;
         throw new Error(error);
+      },
+      onEmbedCreated: (element) => {
+
+        if (typeof userOnEmbedCreated === 'function') {
+          userOnEmbedCreated(element);
+        }
       }
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,6 +109,27 @@ QUnit.module('ReactPlayerLoader', {
     assert.ok(this.fixture.querySelector('div[foo="bar"]'), 'foo="bar" div exists');
   });
 
+  QUnit.test('can set attributes on the embed element', function(assert) {
+    const done = assert.async();
+
+    assert.expect(1);
+
+    ReactDOM.render(
+      React.createElement(ReactPlayerLoader, {
+        accountId: '1',
+        onSuccess: ({ref, type}) => {
+          window.setTimeout(done, 1);
+        },
+        onEmbedCreated: (element) => {
+          element.setAttribute('data-attribute', '1');
+        }
+      }),
+      this.fixture
+    );
+
+    assert.ok(this.fixture.querySelector('video-js[data-attribute="1"]'), 'found data attribute');
+  });
+
   QUnit.test('className defaults to "brightcove-react-player-loader"', function(assert) {
     const done = assert.async();
 


### PR DESCRIPTION
Needed to set additional values on the embed in order to use the audience API, per this related issue in that repository: https://github.com/brightcove/player-loader/issues/63