### PR TITLE
fix:check player reference before calling it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,7 @@ class ReactPlayerLoader extends React.Component {
   updatePlayer(changes) {
 
     // No player exists, player is disposed, or not using the catalog
-    if (!this.player || !this.player.el()) {
+    if (!this.player || !this.player.el || !this.player.el()) {
       return;
     }
 


### PR DESCRIPTION
Fix: check for player's reference before calling it

- make sure the player instance exists before calling `this.player.el()`, happens when using `embedType='iframe'`