### PR TITLE
fix: disable firefox from running in karma

### DIFF
--- a/scripts/karma.conf.js
+++ b/scripts/karma.conf.js
@@ -5,6 +5,9 @@ module.exports = function(config) {
   // see https://github.com/videojs/videojs-generate-karma-config
   // for options
   const options = {
+    browsers(aboutToRun) {
+      return aboutToRun.filter(launcherName => launcherName !== 'FirefoxHeadless');
+    },
     files(defaults) {
       // defaults don't work for this project
       return [

--- a/scripts/karma.conf.js
+++ b/scripts/karma.conf.js
@@ -5,6 +5,8 @@ module.exports = function(config) {
   // see https://github.com/videojs/videojs-generate-karma-config
   // for options
   const options = {
+    // TODO - currently firefox headless fails to run with karma, blocking the npm version script.
+    // We should look into a better workaround that allows us to still run firefox through karma
     browsers(aboutToRun) {
       return aboutToRun.filter(launcherName => launcherName !== 'FirefoxHeadless');
     },


### PR DESCRIPTION
Currently, the latest version of firefox headless cannot be run with the current version of karma in react-player-loader. As a temporary workaround, I have disabled firefox from launching with karma so that the `npm version` script can run successfully. As karma is deprecated, a longer term solution would be using another test runner (https://modern-web.dev/guides/test-runner/getting-started/).

- fix: disabled karma from launching firefox headlessly